### PR TITLE
Allow shared folders to be mounted after installing MSYS2

### DIFF
--- a/plugins/guests/windows/scripts/mount_volume.ps1.erb
+++ b/plugins/guests/windows/scripts/mount_volume.ps1.erb
@@ -17,7 +17,7 @@ if( (Test-Path "$MountPoint") -and (Test-ReparsePoint "$MountPoint") )
 {
   Write-Debug "Junction already exists, so I will delete it"
   # Powershell refuses to delete junctions, oh well use cmd
-  cmd /c rd "$MountPoint"
+  cmd.exe /c rd "$MountPoint"
 
   if ( $LASTEXITCODE -ne 0 )
   {
@@ -40,7 +40,7 @@ if (-not (Test-Path $BaseDirectory))
   New-Item $BaseDirectory -Type Directory -Force | Out-Null
 }
 
-cmd /c mklink /D "$MountPoint" "$VmProviderUncPath" | out-null
+cmd.exe /c mklink /D "$MountPoint" "$VmProviderUncPath" | out-null
 
 if ( $LASTEXITCODE -ne 0 )
 {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vagrant/issues/9975

After installing msys2, there is another `cmd` on the path which prevents shared folders from being mounted. Explicitly calling `cmd.exe` fixes the issue